### PR TITLE
Add restore_token() method

### DIFF
--- a/bin/get_snaps.py
+++ b/bin/get_snaps.py
@@ -3,16 +3,17 @@
 """Basic Snapchat client
 
 Usage:
-  get_snaps.py [-q -z] -u <username> [-p <password>] --gmail=<gmail> --gpasswd=<gpasswd> <path>
+  get_snaps.py [-q -z] -u <username> [-p <password> | -a <auth_token>] --gmail=<gmail> --gpasswd=<gpasswd> <path>
 
 Options:
-  -h --help                 Show usage
-  -q --quiet                Suppress output
-  -u --username=<username>  Username
-  -p --password=<password>  Password (optional, will prompt if omitted)
-     --gmail=<gmail>        Gmail
-     --gpasswd=<gpasswd>    Gmail password
-  -z --unzip                Unzip files
+  -h --help                     Show usage
+  -q --quiet                    Suppress output
+  -u --username=<username>      Username
+  -p --password=<password>      Password (optional, will prompt if omitted)
+     --gmail=<gmail>            Gmail
+     --gpasswd=<gpasswd>        Gmail password
+  -a --auth-token=<auth_token>  Auth token from Snapchat session
+  -z --unzip                    Unzip files
 """
 from __future__ import print_function
 
@@ -50,16 +51,15 @@ def main():
     quiet = arguments['--quiet']
     unzip = arguments['--unzip']
     username = arguments['--username']
-    if arguments['--password'] is None:
-        password = getpass('Password:')
-    else:
-        password = arguments['--password']
+    
+    auth_token = arguments['--auth-token']
     
     gmail = arguments['--gmail']
     if arguments['--gpasswd'] is None:
         gpasswd = getpass('Gmail password:')
     else:
         gpasswd = arguments['--gpasswd']
+
     path = arguments['<path>']
 
     if not os.path.isdir(path):
@@ -67,9 +67,19 @@ def main():
         sys.exit(1)
 
     s = Snapchat()
-    if not s.login(username, password, gmail, gpasswd)['updates_response'].get('logged'):
-        print('Invalid username or password')
-        sys.exit(1)
+
+    if auth_token:
+        s.restore_token(username, auth_token, gmail, gpasswd)
+
+    else:
+        if arguments['--password'] is None:
+            password = getpass('Password:')
+        else:
+            password = arguments['--password']
+
+        if not s.login(username, password, gmail, gpasswd)['updates_response'].get('logged'):
+            print('Invalid username or password')
+            sys.exit(1)
 
     for snap in s.get_snaps():
         process_snap(s, snap, path, quiet, unzip)

--- a/bin/get_stories.py
+++ b/bin/get_stories.py
@@ -3,16 +3,17 @@
 """Basic Snapchat client
 
 Usage:
-  get_stories.py [-q -z] -u <username> [-p <password>] --gmail=<gmail> --gpasswd=<gpasswd> <path>
+  get_stories.py [-q -z] -u <username> [-p <password> | -a <auth_token>] --gmail=<gmail> --gpasswd=<gpasswd> <path>
 
 Options:
-  -h --help                 Show usage
-  -q --quiet                Suppress output
-  -u --username=<username>  Username
-  -p --password=<password>  Password (optional, will prompt if omitted)
-     --gmail=<gmail>        Gmail address
-     --gpasswd=<gpasswd>    Gmail password
-  -z --unzip                Unzip files
+  -h --help                     Show usage
+  -q --quiet                    Suppress output
+  -u --username=<username>      Username
+  -p --password=<password>      Password (optional, will prompt if omitted)
+     --gmail=<gmail>            Gmail address
+     --gpasswd=<gpasswd>        Gmail password
+  -a --auth-token=<auth_token>  Auth token from Snapchat session
+  -z --unzip                    Unzip files
 """
 from __future__ import print_function
 
@@ -33,10 +34,8 @@ def main():
     unzip = arguments['--unzip']
 
     username = arguments['--username']
-    if arguments['--password'] is None:
-        password = getpass('Password:')
-    else:
-        password = arguments['--password']
+
+    auth_token = arguments['--auth-token']
 
     gmail = arguments['--gmail']
     if arguments['--gpasswd'] is None:
@@ -51,9 +50,19 @@ def main():
         sys.exit(1)
 
     s = Snapchat()
-    if not s.login(username, password, gmail, gpasswd)['updates_response'].get('logged'):
-        print('Invalid username or password')
-        sys.exit(1)
+
+    if auth_token:
+        s.restore_token(username, auth_token, gmail, gpasswd)
+
+    else:
+        if arguments['--password'] is None:
+            password = getpass('Password:')
+        else:
+            password = arguments['--password']
+
+        if not s.login(username, password, gmail, gpasswd)['updates_response'].get('logged'):
+            print('Invalid username or password')
+            sys.exit(1)
 
     for snap in s.get_friend_stories():
         filename = '{0}.{1}'.format(snap['id'],

--- a/snapy/__init__.py
+++ b/snapy/__init__.py
@@ -98,6 +98,22 @@ class Snapchat(object):
         self.username = None
         self.auth_token = None
 
+    def restore_token(self, username, auth_token, gmail, gpasswd):
+        """Restore a Snapchat session from an auth_token parameter
+        returned in the response of a login request. Useful for when
+        Snapchat breaks the login API.
+
+        :param username     Snapchat username
+        :param auth_token   Snapchat auth_token
+        :param gmail        Gmail address
+        :param gpasswd      Gmail password
+        """
+        self.username = username
+        self.auth_token = auth_token
+        self.gmail = gmail
+        self.gpasswd = gpasswd
+        self.gauth = get_auth_token(gmail, gpasswd)
+
     def login(self, username, password, gmail, gpasswd):
         """Login to Snapchat account
         Returns a dict containing user information on successful login, the


### PR DESCRIPTION
Since Casper's workaround for generating attestations no longer works (https://github.com/tatosaurus/snapy/issues/10), this adds a function to manually restore an `auth_token` (returned in the response from `/loq/login`) to a Snapchat object instead of logging in with a password. I imagine this will also be useful for future debugging.
