### PR TITLE
Fix get_conversations() for accounts with no conversations

### DIFF
--- a/snapy/__init__.py
+++ b/snapy/__init__.py
@@ -209,10 +209,10 @@ class Snapchat(object):
         updates = self.get_updates()
         try:
             last = updates['conversations_response'][-2]
-        except KeyError:
+            offset = last['iter_token']
+        except IndexError:
             print "No conversations except TeamSnapchat"
         
-        offset = last['iter_token']
         
         convos = updates['conversations_response']
         """


### PR DESCRIPTION
Tested on a new account where the only things in `conversations_reponse` were from `teamsnapchat`. This throws an IndexError, not a KeyError.
