### PR TITLE
Fix get_snaps() for conversations with multiple snaps

### DIFF
--- a/snapy/__init__.py
+++ b/snapy/__init__.py
@@ -268,7 +268,7 @@ class Snapchat(object):
         
         for conversation in conversations:
             num_pending = len(conversation['pending_received_snaps'])
-            for i in range(0,num_pending):
+            for i in range(0, num_pending):
                 snap = (_map_keys(conversation['pending_received_snaps'][i]))
                 snaps.append(snap)
 

--- a/snapy/__init__.py
+++ b/snapy/__init__.py
@@ -267,8 +267,9 @@ class Snapchat(object):
         conversations = self.get_conversations()
         
         for conversation in conversations:
-            if len(conversation['pending_received_snaps']) > 0:
-                snap = (_map_keys(conversation['pending_received_snaps'][0]))
+            num_pending = len(conversation['pending_received_snaps'])
+            for i in range(0,num_pending):
+                snap = (_map_keys(conversation['pending_received_snaps'][i]))
                 snaps.append(snap)
 
         return snaps


### PR DESCRIPTION
Currently, if a conversation has more than one snap in it, it will not download anything but the first one (earliest chronologically). This seems to fix that.
