### PR TITLE
Casper API status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Snapy
 ===============
 
-[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) (https://packagist.org/packages/mgp25/snapapi) ![CasperStatus](https://www.mgp25.com/cstatus/status.svg)
 
 A fork of pysnap by [martinp](https://github.com/martinp/pysnap) updated to
 use the new Snapchat API. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Snapy
 ===============
 
-[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) (https://packagist.org/packages/mgp25/snapapi) ![CasperStatus](https://www.mgp25.com/cstatus/status.svg)
+[![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome) ![CasperStatus](https://www.mgp25.com/cstatus/status.svg)
 
 A fork of pysnap by [martinp](https://github.com/martinp/pysnap) updated to
 use the new Snapchat API. 


### PR DESCRIPTION
Adds a button to the readme to show the status of the Casper API. Idea adopted from https://github.com/mgp25/SC-API/commit/dc40015a399a16ff18775c714df8711fa8a5ff09.
